### PR TITLE
fix: add canonical URLs to prevent duplicate content issues

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,13 @@
     {{ end }}
   {{ end }}
   <meta name="description" content="{{ $desc }}" />
+  {{ $canonical := .Permalink }}
+  {{ if and .IsNode .Paginator }}
+    {{ if gt .Paginator.PageNumber 1 }}
+      {{ $canonical = .Paginator.URL }}
+    {{ end }}
+  {{ end }}
+  <link rel="canonical" href="{{ $canonical }}" />
   {{ template "_internal/opengraph.html" . }}
  <link rel="stylesheet" href="/fonts/fonts.css" />
   <link rel="preload" href="/fonts/fonts.css" as="style" />


### PR DESCRIPTION
Adds canonical URL meta tags to prevent Google from seeing category pages as duplicates.

- Adds canonical links to all pages
- For paginated pages, canonical points to base URL (not page-specific URL)
- Fixes SEO duplicate content warnings from Google Search Console

Resolves duplicate content issues for category pages.