### PR TITLE
Release: v0.12.2-csp-alpinejs-fix - Fix theme switcher Alpine.js CSP

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
     <meta name="color-scheme" content="light dark">
 
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://platform.twitter.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://platform.twitter.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://gmail.us8.list-manage.com; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://platform.twitter.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://platform.twitter.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com; base-uri 'self'; form-action 'self' https://gmail.us8.list-manage.com; upgrade-insecure-requests;">
 
     {{ $title := .Title }}
     {{ $siteTitle := .Site.Title }}


### PR DESCRIPTION
Fixes Alpine.js blocked by CSP, resolving theme switcher functionality.

**Changes:**
- Add https://cdn.jsdelivr.net to script-src directive
- Remove invalid frame-ancestors meta tag directive
- Alpine.js v3.14.1 now loads correctly

Closes #theme-switcher issue