### PR TITLE
fix(ci): suppress Node.js 20 deprecation warnings in GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+# Force Node.js 24 for all actions (Node.js 20 deprecated, enforced June 2026)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 concurrency:
   group: 'pages'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -13,6 +13,10 @@ permissions:
   contents: write
   packages: write
 
+# Force Node.js 24 for all actions (Node.js 20 deprecated, enforced June 2026)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate-request:
     name: Validate Release Request
@@ -203,8 +207,6 @@ jobs:
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           hugo-version: 'latest'
           extended: true


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at workflow level in `cicd.yml`, `release-controller.yml`, and `e2e.yml`
- Remove redundant step-level env var from release-controller hugo step (now covered by workflow-level)
- No Node 24-compatible versions exist yet for `configure-pages@v5`, `deploy-pages@v4`, `upload-pages-artifact@v4`, or `actions-hugo@v3` — this env var is the recommended workaround until they ship updates

## Test plan

- [ ] CI/CD pipeline runs without Node.js 20 deprecation warnings
- [ ] Build and deploy succeed normally
- [ ] E2E workflow runs without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)